### PR TITLE
Fix output for large files

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function() {
   var options;
   var callback;
   var pdSpawn;
-  var result;
+  var result = "";
   var isURL;
 
   // Event Handlers
@@ -22,7 +22,7 @@ module.exports = function() {
   };
 
   onStdOutData = function (data) {
-    result = ""+data;
+    result += data;
   };
 
   onStdOutEnd = function () {


### PR DESCRIPTION
The current implementation's output in stdout is limited to the
output of the last stream buffer which is not very much (~3600 bytes).
This change allows handling outputs of large files.

Test Source : http://pandoc.org/demo/MANUAL.txt
Expected    : http://pandoc.org/demo/example1.html